### PR TITLE
Update udev rules to include Feather 32u4 Bluefruit LE.

### DIFF
--- a/99-adafruit-boards.rules
+++ b/99-adafruit-boards.rules
@@ -12,7 +12,11 @@
 # Tested with Ubuntu 14.04 and 12.04.  Other distributions might need to update GROUP="dialout"
 # to another group value like "users".
 SUBSYSTEM=="usb", ATTR{idProduct}=="0c9f", ATTRS{idVendor}=="1781", MODE="0660", GROUP="dialout"
+# Similar to above, but for the Feather 32u4 Bluefruit LE
+SUBSYSTEM=="usb", ATTR{idProduct}=="800c", ATTRS{idVendor}=="239c", MODE="0660", GROUP="dialout"
 
 # Rule to blacklist Adafruit USB CDC boards from being manipulated by ModemManager.
 # Fixes issue with hanging references to /dev/ttyACM* devices on Ubuntu 15.04.
 ATTRS{idVendor}=="239a", ENV{ID_MM_DEVICE_IGNORE}="1"
+# Similar to above, but for the Feather 32u4 Bluefruit LE
+ATTRS{idVendor}=="239c", ENV{ID_MM_DEVICE_IGNORE}="1"


### PR DESCRIPTION
While configuring the Arduino IDE for the Adafruit Feather 32u4 Bluefruit LE, the following web page told me how to fix the udev issue I was seeing on Debian Jessie:

https://learn.adafruit.com/adafruit-feather-32u4-bluefruit-le/using-with-arduino-ide

Near the bottom of that page, it refers to another page which explains how to fetch and install the udev rules from this repo.  But those rules do not seem to cover the Feather 32u4 Bluefruit LE.  At least they didn't fix the issue for me until I added lines with the Feather's Vendor ID and Product ID.  This pull request adds those lines.
